### PR TITLE
Only start TM after CDN snapshot

### DIFF
--- a/infrastructure/cdn-in-a-box/traffic_monitor/run.sh
+++ b/infrastructure/cdn-in-a-box/traffic_monitor/run.sh
@@ -96,6 +96,12 @@ export TO_PASSWORD=$TO_ADMIN_PASSWORD
 
 touch /opt/traffic_monitor/var/log/traffic_monitor.log
 
+# Do not start until there is a valid CRConfig available
+until [ $(to-get '/CRConfig-Snapshots/CDN-in-a-Box/CRConfig.json' 2>/dev/null | jq -c -e '.config|length') -gt 0 ] ; do 
+	echo "Waiting on valid CRConfig..."; 
+  	sleep 3; 
+done
+
 cd /opt/traffic_monitor
 /opt/traffic_monitor/bin/traffic_monitor -opsCfg /opt/traffic_monitor/conf/traffic_ops.cfg -config /opt/traffic_monitor/conf/traffic_monitor.cfg &
 disown

--- a/infrastructure/cdn-in-a-box/traffic_ops/run-go.sh
+++ b/infrastructure/cdn-in-a-box/traffic_ops/run-go.sh
@@ -73,8 +73,51 @@ TO_USER=$TO_ADMIN_USER TO_PASSWORD=$TO_ADMIN_PASSWORD to-enroll $(hostname -s) &
 
 ./bin/traffic_ops_golang -cfg $CDNCONF -dbcfg $DBCONF -riakcfg $RIAKCONF &
 
-sleep 5
-
 to-enroll "to" ALL || (while true; do echo "enroll failed."; sleep 3 ; done)
+
+### Workaround: Start DeliveryService and Edge association
+while true; do
+  edge_name="$(to-get 'api/1.3/servers/hostname/edge/details' 2>/dev/null | jq -r -c '.response|.hostName')"
+  ds_name="$(to-get 'api/1.3/deliveryservices' 2>/dev/null | jq -r -c '.response[].xmlId')"
+
+  if [ -n "$edge_name" ] && [ "$ds_name" ] ; then
+    tmp_file=$(mktemp)
+    echo "{ \"xmlId\" : \"$ds_name\", \"serverNames\": [ \"$edge_name\" ] }" > $tmp_file
+    cp $tmp_file /shared/enroller/deliveryservice_servers/
+    break
+  else 
+    echo "Waiting for delivery service and edge to exist..."
+  fi
+
+  sleep 2
+done
+
+while true; do
+  echo "Verifying that edge was associated to delivery service..."
+
+  edge_name="$(to-get 'api/1.3/servers/hostname/edge/details' 2>/dev/null | jq -r -c '.response|.hostName')"
+  ds_name="$(to-get 'api/1.3/deliveryservices' 2>/dev/null | jq -r -c '.response[].xmlId')"
+  ds_id="$(to-get 'api/1.3/deliveryservices' 2>/dev/null | jq -r -c '.response[].id')"
+  edge_verify=$(to-get "/api/1.2/deliveryservices/$ds_id/servers" | jq -r '.response[]|.hostName')
+
+  if [[ $edge_verify = $edge_name ]] ; then
+    break
+  fi
+
+  sleep 2
+done
+
+# Snapshot the CDN 
+until [ $(to-get '/CRConfig-Snapshots/CDN-in-a-Box/CRConfig.json' 2>/dev/null | jq -c -e '.config|length') -gt 0 ] ; do 
+  sleep 2
+  echo "Do Snapshot for CDN-in-a-Box..."; 
+  to-put 'api/1.3/cdns/2/snapshot'
+done
+
+# Queue Updates 
+sleep 1
+to-post 'api/1.3/cdns/2/queue_update' '{"action":"queue"}'
+
+### Workaround: End DeliveryService and Edge association
 
 exec tail -f /dev/null

--- a/infrastructure/cdn-in-a-box/traffic_router/run.sh
+++ b/infrastructure/cdn-in-a-box/traffic_router/run.sh
@@ -96,7 +96,7 @@ echo "traffic_monitor.properties.reload.period=60000" >> $TM_PROPERTIES
 
 # Wait for traffic monitor
 until nc $TM_FQDN $TM_PORT </dev/null >/dev/null 2>&1; do
-	echo "waiting for enroller"
+  echo "Waiting for Traffic Monitor to start..."
   sleep 3
 done
 


### PR DESCRIPTION
#### What does this PR do?

- Fixes the Traffic Monitor nil session problem.
- No longer requires a Traffic Monitor restart.
- Automatic Snapshot of CDN-in-a-Box
- Automatic queue server updates
- Work around for edge server to delivery service "demo1" association.

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?


#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



